### PR TITLE
test: enable bind/listen/shutdown ops tests

### DIFF
--- a/lio/include/lio.h
+++ b/lio/include/lio.h
@@ -177,8 +177,8 @@ void lio_accept(struct lio_handle_t *lio, intptr_t fd, void (*callback)(intptr_t
  * - `callback(result, buf, len)`: bytes sent (or negative errno), buffer
  *
  * # Safety
- * `lio` must be valid; `buf` must be at least `buf_len` bytes allocated with
- * `malloc`.
+ * `lio` must be valid; `buf` must point to at least `buf_len` bytes allocated
+ * with `malloc`.
  */
 void lio_send(struct lio_handle_t *lio,
               intptr_t fd,
@@ -195,8 +195,8 @@ void lio_send(struct lio_handle_t *lio,
  * - `callback(result, buf, len)`: bytes received (or negative errno), buffer
  *
  * # Safety
- * `lio` must be valid; `buf` must be at least `buf_len` bytes allocated with
- * `malloc`.
+ * `lio` must be valid; `buf` must be a live buffer previously allocated by
+ * [`lio_buf_alloc(buf_len)`].
  */
 void lio_recv(struct lio_handle_t *lio,
               intptr_t fd,

--- a/lio/src/api/ops.rs
+++ b/lio/src/api/ops.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unnecessary_lazy_evaluations)]
+
 //! I/O operation definitions.
 //!
 //! This module contains all the typed operation structs that implement `TypedOp`.

--- a/lio/src/backend/ds.rs
+++ b/lio/src/backend/ds.rs
@@ -2773,7 +2773,9 @@ impl DST {
             }
             self.poll_pending_node(to.node_id);
           }
-          DSTEvent::DatagramDelivered { from, from_addr, to, packet, .. } => {
+          DSTEvent::DatagramDelivered {
+            from, from_addr, to, packet, ..
+          } => {
             if !self
               .inner
               .borrow_mut()
@@ -3383,8 +3385,9 @@ impl DSTBackend {
         let mut inner = self.inner.borrow_mut();
         let ready_at_tick =
           inner.tick + inner.event_delay_ticks_for(self.node_id, source_seq, 2);
-        let from_addr = bound
-          .unwrap_or_else(|| Self::synthetic_peer_addr(domain, self.node_id, raw));
+        let from_addr = bound.unwrap_or_else(|| {
+          Self::synthetic_peer_addr(domain, self.node_id, raw)
+        });
         inner.enqueue_event(DSTEvent::DatagramDelivered {
           ready_at_tick,
           source_node: self.node_id,

--- a/lio/src/backend/ds.rs
+++ b/lio/src/backend/ds.rs
@@ -1,3 +1,12 @@
+#![allow(
+  clippy::large_enum_variant,
+  clippy::question_mark,
+  clippy::undocumented_unsafe_blocks,
+  clippy::unnecessary_cast,
+  clippy::unnecessary_map_or,
+  clippy::collapsible_if
+)]
+
 //! Deterministic simulation backend for higher-level tests.
 //!
 //! `DSBackend` never calls into the operating system. Instead it executes

--- a/lio/src/backend/impls/io_uring.rs
+++ b/lio/src/backend/impls/io_uring.rs
@@ -342,10 +342,8 @@ impl LoweredState {
         let state = unsafe { state.as_ref() };
         if let (Some(out), Some((storage, len))) =
           (state.from_out, state.addr.as_ref())
-          && let Ok(addr) = crate::backend::op::socket_addr_buf_from_storage(
-            storage,
-            *len,
-          )
+          && let Ok(addr) =
+            crate::backend::op::socket_addr_buf_from_storage(storage, *len)
         {
           unsafe {
             *out.as_ptr() = addr;

--- a/lio/src/backend/impls/io_uring.rs
+++ b/lio/src/backend/impls/io_uring.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 //! `lio`-provided [`IoBackend`] impl for `io_uring`.
 
 use std::io;

--- a/lio/src/backend/impls/pollingv2/mod.rs
+++ b/lio/src/backend/impls/pollingv2/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 //! `lio`-provided [`IoBackend`] impl for `epoll`/`kqueue` (platform-specific).
 
 mod os;

--- a/lio/src/backend/impls/pollingv2/tests.rs
+++ b/lio/src/backend/impls/pollingv2/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unnecessary_safety_comment)]
+
 use super::{Interest, ReadinessPoll};
 use std::io;
 use std::os::fd::{AsRawFd, RawFd};

--- a/lio/src/backend/op.rs
+++ b/lio/src/backend/op.rs
@@ -525,10 +525,7 @@ impl MsgRecv {
   }
 
   #[inline]
-  pub fn with_from(
-    bufs: &[MsgBufMut],
-    from: NonNull<SocketAddrBuf>,
-  ) -> Self {
+  pub fn with_from(bufs: &[MsgBufMut], from: NonNull<SocketAddrBuf>) -> Self {
     let mut msg = Self::new(bufs);
     msg.from = Some(from);
     msg
@@ -699,14 +696,8 @@ impl FileStat {
 
 #[derive(Clone, Debug)]
 pub enum StatTarget {
-  Path {
-    dir_fd: Resource,
-    path: NonNull<c_char>,
-    follow_symlinks: bool,
-  },
-  Fd {
-    fd: Resource,
-  },
+  Path { dir_fd: Resource, path: NonNull<c_char>, follow_symlinks: bool },
+  Fd { fd: Resource },
 }
 
 #[cfg(all(feature = "backend_impls", unix))]

--- a/lio/src/ffi.rs
+++ b/lio/src/ffi.rs
@@ -711,7 +711,7 @@ pub unsafe extern "C" fn lio_sendto(
   // SAFETY: caller guarantees fd is valid per fn contract
   let resource = unsafe { fd_to_borrowed_resource(fd) };
   // SAFETY: caller guarantees lio is valid per fn contract
-  crate::api::io::Io::from_op(api::Send::new(
+  crate::api::io::Io::from_op(api::ops::Send::new(
     resource.clone(),
     vec,
     Some(socket_addr),

--- a/lio/src/fs.rs
+++ b/lio/src/fs.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::never_loop)]
+
 //! Filesystem resource types.
 
 use std::{

--- a/lio/src/net/socket.rs
+++ b/lio/src/net/socket.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 use std::net::SocketAddr;
 
 use crate::{

--- a/lio/tests/common.rs
+++ b/lio/tests/common.rs
@@ -150,6 +150,7 @@ impl Drop for TempFile {
 
 /// Poll the lio event loop until a result is received on the channel.
 /// Blocks in kqueue/epoll for up to 5ms per iteration — no busy-spin, no attempt cap.
+#[allow(dead_code)]
 pub fn poll_until_recv<T>(lio: &mut Lio, receiver: &mpsc::Receiver<T>) -> T {
   {
     for _ in 0..1_000 {

--- a/lio/tests/net_socket_datagram.rs
+++ b/lio/tests/net_socket_datagram.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 #![cfg(feature = "high")]
 
 use std::{cell::RefCell, net::SocketAddr, rc::Rc};

--- a/lio/tests/net_socket_datagram.rs
+++ b/lio/tests/net_socket_datagram.rs
@@ -13,7 +13,8 @@ struct ReceiverNode {
   socket_rx: Option<Receiver<std::io::Result<Socket>>>,
   socket: Option<Socket>,
   bind_rx: Option<Receiver<std::io::Result<()>>>,
-  recv_rx: Option<Receiver<(std::io::Result<i32>, Vec<u8>, Option<SocketAddr>)>>,
+  recv_rx:
+    Option<Receiver<(std::io::Result<i32>, Vec<u8>, Option<SocketAddr>)>>,
   recv_done: Rc<RefCell<Option<(Vec<u8>, Option<SocketAddr>)>>>,
 }
 
@@ -21,7 +22,13 @@ impl ReceiverNode {
   fn new(
     recv_done: Rc<RefCell<Option<(Vec<u8>, Option<SocketAddr>)>>>,
   ) -> Self {
-    Self { socket_rx: None, socket: None, bind_rx: None, recv_rx: None, recv_done }
+    Self {
+      socket_rx: None,
+      socket: None,
+      bind_rx: None,
+      recv_rx: None,
+      recv_done,
+    }
   }
 
   fn drive(&mut self, bind_addr: SocketAddr) {
@@ -80,7 +87,13 @@ struct SenderNode {
 
 impl SenderNode {
   fn new(send_done: Rc<RefCell<bool>>) -> Self {
-    Self { socket_rx: None, socket: None, bind_rx: None, send_rx: None, send_done }
+    Self {
+      socket_rx: None,
+      socket: None,
+      bind_rx: None,
+      send_rx: None,
+      send_done,
+    }
   }
 
   fn drive(&mut self, bind_addr: SocketAddr, peer_addr: SocketAddr) {
@@ -119,7 +132,8 @@ impl SenderNode {
       self.send_rx = Some(socket.sendto(b"ping".to_vec(), peer_addr).send());
     }
 
-    if let Some((result, buf)) = self.send_rx.as_mut().and_then(Receiver::try_recv)
+    if let Some((result, buf)) =
+      self.send_rx.as_mut().and_then(Receiver::try_recv)
     {
       assert_eq!(result.unwrap(), buf.len() as i32);
       *self.send_done.borrow_mut() = true;

--- a/lio/tests/net_udp.rs
+++ b/lio/tests/net_udp.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 #![cfg(feature = "high")]
 
 use std::{cell::RefCell, net::SocketAddr, rc::Rc};

--- a/lio/tests/net_udp.rs
+++ b/lio/tests/net_udp.rs
@@ -53,7 +53,8 @@ impl ReceiverNode {
 struct DatagramReceiverNode {
   socket_rx: Option<Receiver<std::io::Result<UdpSocket>>>,
   socket: Option<UdpSocket>,
-  recv_rx: Option<Receiver<(std::io::Result<i32>, Vec<u8>, Option<SocketAddr>)>>,
+  recv_rx:
+    Option<Receiver<(std::io::Result<i32>, Vec<u8>, Option<SocketAddr>)>>,
   recv_done: Rc<RefCell<Option<(Vec<u8>, Option<SocketAddr>)>>>,
 }
 

--- a/lio/tests/ops.rs
+++ b/lio/tests/ops.rs
@@ -1,10 +1,12 @@
 mod ops {
   mod accept;
+  mod bind;
   mod common;
   mod connect;
   mod getcwd;
   mod interval;
   mod linkat;
+  mod listen;
   mod mkdirat;
   mod openat;
   mod readdir;
@@ -15,6 +17,7 @@ mod ops {
   mod rw;
   mod send;
   mod sendto;
+  mod shutdown;
   mod sleep;
   mod socket;
   #[cfg(unix)]

--- a/lio/tests/ops/bind.rs
+++ b/lio/tests/ops/bind.rs
@@ -1,8 +1,10 @@
-#![allow(clippy::duplicate_mod, clippy::unnecessary_mut_passed, clippy::expect_fun_call)]
+#![allow(
+  clippy::duplicate_mod,
+  clippy::unnecessary_mut_passed,
+  clippy::expect_fun_call
+)]
 
-mod common;
-
-use common::poll_until_recv;
+use super::common::{self, poll_until_recv};
 use lio::Lio;
 use lio::api::bind;
 use std::{
@@ -15,13 +17,8 @@ use std::{
 fn test_bind_ipv4_any_port() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   // Bind to 0.0.0.0:0 (any available port)
   let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
@@ -49,13 +46,8 @@ fn test_bind_ipv4_any_port() {
 fn test_bind_ipv4_specific_port() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   // Bind to a high port number
   let addr: SocketAddr = "127.0.0.1:19999".parse().unwrap();
@@ -84,13 +76,8 @@ fn test_bind_ipv4_specific_port() {
 fn test_bind_ipv6() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
-
-  common::tcp6_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock = poll_until_recv(&mut lio, &receiver_sock)
-    .expect("Failed to create IPv6 socket");
+  let sock = common::tcp6_socket();
 
   // Bind to IPv6 any address
   let addr: SocketAddr = "[::]:0".parse().unwrap();
@@ -119,13 +106,8 @@ fn test_bind_ipv6() {
 fn test_bind_udp() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
-
-  common::udp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock = poll_until_recv(&mut lio, &receiver_sock)
-    .expect("Failed to create UDP socket");
+  let sock = common::udp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -156,13 +138,8 @@ fn test_bind_udp() {
 fn test_bind_already_bound() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock1 = poll_until_recv(&mut lio, &receiver_sock)
-    .expect("Failed to create first socket");
+  let sock1 = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -190,10 +167,7 @@ fn test_bind_already_bound() {
   };
 
   // Try to bind another socket to the same address
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock2 = poll_until_recv(&mut lio, &receiver_sock)
-    .expect("Failed to create second socket");
+  let sock2 = common::tcp_socket();
 
   let port = u16::from_be(bound_addr.sin_port);
   let addr2: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
@@ -211,13 +185,8 @@ fn test_bind_already_bound() {
 fn test_bind_double_bind() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -239,13 +208,8 @@ fn test_bind_double_bind() {
 fn test_bind_with_reuseaddr() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock1 = poll_until_recv(&mut lio, &receiver_sock)
-    .expect("Failed to create first socket");
+  let sock1 = common::tcp_socket();
 
   // Enable SO_REUSEADDR on first socket
   unsafe {
@@ -270,10 +234,7 @@ fn test_bind_with_reuseaddr() {
   drop(sock1);
 
   // Immediately bind another socket to the same address with SO_REUSEADDR
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock2 = poll_until_recv(&mut lio, &receiver_sock)
-    .expect("Failed to create second socket");
+  let sock2 = common::tcp_socket();
 
   unsafe {
     let reuse: i32 = 1;
@@ -298,13 +259,8 @@ fn test_bind_with_reuseaddr() {
 fn test_bind_localhost() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -333,25 +289,14 @@ fn test_bind_localhost() {
 fn test_bind_concurrent() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_bind, receiver_bind) = mpsc::channel();
 
   // Test binding multiple sockets concurrently to different ports
-  for _ in 20000..20010 {
-    common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-  }
-
-  let mut socks = Vec::new();
-  for _ in 0..10 {
-    let sock = poll_until_recv(&mut lio, &receiver_sock)
-      .expect("Failed to create socket");
-    socks.push(sock);
-  }
+  let socks: Vec<_> = (0..10).map(|_| common::tcp_socket()).collect();
 
   // Set SO_REUSEADDR and bind each socket
-  for (i, sock) in socks.iter().enumerate() {
-    let port = 20000 + i;
-    let addr: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
+  for sock in socks.iter() {
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
     bind(sock, addr).with_lio(&mut lio).send_with(sender_bind.clone());
   }
 

--- a/lio/tests/ops/listen.rs
+++ b/lio/tests/ops/listen.rs
@@ -1,8 +1,10 @@
-#![allow(clippy::duplicate_mod, clippy::unnecessary_mut_passed, clippy::expect_fun_call)]
+#![allow(
+  clippy::duplicate_mod,
+  clippy::unnecessary_mut_passed,
+  clippy::expect_fun_call
+)]
 
-mod common;
-
-use common::poll_until_recv;
+use super::common::{self, poll_until_recv};
 use lio::Lio;
 use lio::api;
 use std::{
@@ -16,13 +18,8 @@ use std::{
 fn test_listen_basic() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_unit, receiver_unit) = mpsc::channel::<std::io::Result<()>>();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -61,13 +58,8 @@ fn test_listen_basic() {
 fn test_listen_with_backlog() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_unit, receiver_unit) = mpsc::channel::<std::io::Result<()>>();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -101,13 +93,8 @@ fn test_listen_with_backlog() {
 fn test_listen_large_backlog() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_unit, receiver_unit) = mpsc::channel::<std::io::Result<()>>();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -140,12 +127,7 @@ fn test_listen_large_backlog() {
 fn test_listen_without_bind() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let (sender_l, receiver_l) = mpsc::channel::<std::io::Result<()>>();
 
@@ -163,13 +145,8 @@ fn test_listen_without_bind() {
 fn test_listen_ipv6() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_unit, receiver_unit) = mpsc::channel::<std::io::Result<()>>();
-
-  common::tcp6_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock = poll_until_recv(&mut lio, &receiver_sock)
-    .expect("Failed to create IPv6 socket");
+  let sock = common::tcp6_socket();
 
   let addr: SocketAddr = "[::1]:0".parse().unwrap();
 
@@ -202,13 +179,8 @@ fn test_listen_ipv6() {
 fn test_listen_on_udp() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_unit, receiver_unit) = mpsc::channel::<std::io::Result<()>>();
-
-  common::udp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock = poll_until_recv(&mut lio, &receiver_sock)
-    .expect("Failed to create UDP socket");
+  let sock = common::udp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -230,13 +202,8 @@ fn test_listen_on_udp() {
 fn test_listen_twice() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_unit, receiver_unit) = mpsc::channel::<std::io::Result<()>>();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -264,13 +231,8 @@ fn test_listen_twice() {
 fn test_listen_zero_backlog() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_unit, receiver_unit) = mpsc::channel::<std::io::Result<()>>();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -303,12 +265,7 @@ fn test_listen_zero_backlog() {
 fn test_listen_after_close() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -339,19 +296,8 @@ fn test_listen_after_close() {
 fn test_listen_concurrent() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender, receiver) = mpsc::channel();
-
   // Test listening on multiple sockets concurrently
-  for _ in 0..10 {
-    common::tcp_socket().with_lio(&mut lio).send_with(sender.clone());
-  }
-
-  let mut sockets = Vec::new();
-  for _ in 0..10 {
-    let sock =
-      poll_until_recv(&mut lio, &receiver).expect("Socket creation failed");
-    sockets.push(sock);
-  }
+  let sockets: Vec<_> = (0..10).map(|_| common::tcp_socket()).collect();
 
   let (sender_bind, receiver_bind) = mpsc::channel::<std::io::Result<()>>();
 
@@ -395,13 +341,8 @@ fn test_listen_concurrent() {
 fn test_listen_on_all_interfaces() {
   let mut lio = Lio::new(64).unwrap();
 
-  let (sender_sock, receiver_sock) = mpsc::channel();
   let (sender_unit, receiver_unit) = mpsc::channel::<std::io::Result<()>>();
-
-  common::tcp_socket().with_lio(&mut lio).send_with(sender_sock.clone());
-
-  let sock =
-    poll_until_recv(&mut lio, &receiver_sock).expect("Failed to create socket");
+  let sock = common::tcp_socket();
 
   // Bind to 0.0.0.0 (all interfaces)
   let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();

--- a/lio/tests/ops/recvfrom.rs
+++ b/lio/tests/ops/recvfrom.rs
@@ -89,6 +89,7 @@ fn send_all(fd: &Resource, data: &[u8]) {
   }
 }
 
+#[allow(dead_code)]
 fn get_peer_addr(sock: &Resource) -> SocketAddr {
   unsafe {
     let mut addr_storage = std::mem::MaybeUninit::<libc::sockaddr_in>::zeroed();

--- a/lio/tests/ops/recvfrom.rs
+++ b/lio/tests/ops/recvfrom.rs
@@ -13,8 +13,8 @@ use super::common::{
 use lio::Lio;
 use lio::api;
 use lio::api::resource::Resource;
-use std::os::fd::{AsFd, AsRawFd, FromRawFd};
 use std::net::{SocketAddr, UdpSocket};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd};
 use std::sync::mpsc;
 
 struct UdpPair {
@@ -42,7 +42,8 @@ fn setup_udp_pair() -> UdpPair {
       }
       sockaddr.sin_family = libc::AF_INET as libc::sa_family_t;
       sockaddr.sin_port = addr.port().to_be();
-      sockaddr.sin_addr = libc::in_addr { s_addr: u32::from(*addr.ip()).to_be() };
+      sockaddr.sin_addr =
+        libc::in_addr { s_addr: u32::from(*addr.ip()).to_be() };
       sockaddr
     }
     SocketAddr::V6(_) => unreachable!("IPv4-only test helper"),
@@ -62,11 +63,11 @@ fn setup_udp_pair() -> UdpPair {
   );
   let recv_addr = get_bound_addr(&receiver);
 
-  let sender = UdpSocket::bind("127.0.0.1:0").expect("failed to bind sender socket");
-  let sender_addr = sender.local_addr().expect("failed to query sender address");
-  sender
-    .connect(recv_addr)
-    .expect("failed to connect sender socket");
+  let sender =
+    UdpSocket::bind("127.0.0.1:0").expect("failed to bind sender socket");
+  let sender_addr =
+    sender.local_addr().expect("failed to query sender address");
+  sender.connect(recv_addr).expect("failed to connect sender socket");
 
   UdpPair { receiver, sender, sender_addr }
 }
@@ -113,8 +114,9 @@ fn get_peer_addr(sock: &Resource) -> SocketAddr {
 #[cfg(unix)]
 fn setup_unix_dgram_pair() -> (Resource, Resource) {
   let mut fds = [0; 2];
-  let result =
-    unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_DGRAM, 0, fds.as_mut_ptr()) };
+  let result = unsafe {
+    libc::socketpair(libc::AF_UNIX, libc::SOCK_DGRAM, 0, fds.as_mut_ptr())
+  };
   assert_eq!(
     result,
     0,
@@ -140,8 +142,7 @@ fn basic() {
     std::io::Result<i32>,
     Vec<u8>,
     Option<SocketAddr>,
-  ) =
-    poll_recv(&mut lio, &mut receiver_op);
+  ) = poll_recv(&mut lio, &mut receiver_op);
   let bytes_received = bytes_received.expect("recvfrom failed") as usize;
 
   assert_eq!(bytes_received, data.len());
@@ -167,8 +168,7 @@ fn multiple() {
       std::io::Result<i32>,
       Vec<u8>,
       Option<SocketAddr>,
-    ) =
-      poll_until_recv(&mut lio, &receiver_recv);
+    ) = poll_until_recv(&mut lio, &receiver_recv);
     let bytes_received = bytes_received.expect("recvfrom failed") as usize;
 
     assert_eq!(bytes_received, data.len());
@@ -194,8 +194,7 @@ fn partial_buffer() {
     std::io::Result<i32>,
     Vec<u8>,
     Option<SocketAddr>,
-  ) =
-    poll_until_recv(&mut lio, &receiver_recv);
+  ) = poll_until_recv(&mut lio, &receiver_recv);
   let bytes_received = bytes_received.expect("recvfrom failed") as usize;
 
   assert!(bytes_received <= 10);
@@ -220,9 +219,9 @@ fn with_flags() {
     std::io::Result<i32>,
     Vec<u8>,
     Option<SocketAddr>,
-  ) =
-    poll_until_recv(&mut lio, &receiver_recv);
-  let bytes_received = bytes_received.expect("recvfrom with flags failed") as usize;
+  ) = poll_until_recv(&mut lio, &receiver_recv);
+  let bytes_received =
+    bytes_received.expect("recvfrom with flags failed") as usize;
 
   assert_eq!(bytes_received, data.len());
   assert_eq!(&received_buf[..bytes_received], data.as_slice());
@@ -232,20 +231,21 @@ fn with_flags() {
 #[test]
 fn tcp_stream() {
   let mut lio = Lio::new(64).unwrap();
-  let TcpPair { server_sock: _, client_sock, accepted_fd } = setup_tcp_pair(&mut lio);
+  let TcpPair { server_sock: _, client_sock, accepted_fd } =
+    setup_tcp_pair(&mut lio);
 
   let data = b"tcp recvfrom".to_vec();
   send_all(&client_sock, &data);
 
-  let mut receiver_op =
-    api::recvfrom(&accepted_fd, vec![0u8; 1024], None).with_lio(&mut lio).send();
+  let mut receiver_op = api::recvfrom(&accepted_fd, vec![0u8; 1024], None)
+    .with_lio(&mut lio)
+    .send();
 
   let (bytes_received, received_buf, from_addr): (
     std::io::Result<i32>,
     Vec<u8>,
     Option<SocketAddr>,
-  ) =
-    poll_recv(&mut lio, &mut receiver_op);
+  ) = poll_recv(&mut lio, &mut receiver_op);
   let bytes_received = bytes_received.expect("recvfrom failed on TCP") as usize;
 
   assert_eq!(bytes_received, data.len());
@@ -269,9 +269,9 @@ fn unix_dgram() {
     std::io::Result<i32>,
     Vec<u8>,
     Option<SocketAddr>,
-  ) =
-    poll_recv(&mut lio, &mut receiver_op);
-  let bytes_received = bytes_received.expect("recvfrom failed on Unix dgram") as usize;
+  ) = poll_recv(&mut lio, &mut receiver_op);
+  let bytes_received =
+    bytes_received.expect("recvfrom failed on Unix dgram") as usize;
 
   assert_eq!(bytes_received, data.len());
   assert_eq!(&received_buf[..bytes_received], data.as_slice());

--- a/lio/tests/ops/sendto.rs
+++ b/lio/tests/ops/sendto.rs
@@ -13,8 +13,8 @@ use super::common::{
 use lio::Lio;
 use lio::api;
 use lio::api::resource::Resource;
-use std::os::fd::{AsFd, AsRawFd};
 use std::net::{SocketAddr, UdpSocket};
+use std::os::fd::{AsFd, AsRawFd};
 use std::sync::mpsc;
 
 struct UdpPair {
@@ -25,7 +25,8 @@ struct UdpPair {
 
 fn setup_udp_pair() -> UdpPair {
   let sender = udp_socket();
-  let receiver = UdpSocket::bind("127.0.0.1:0").expect("failed to bind receiver socket");
+  let receiver =
+    UdpSocket::bind("127.0.0.1:0").expect("failed to bind receiver socket");
   let receiver_addr =
     receiver.local_addr().expect("failed to query receiver address");
 
@@ -46,7 +47,8 @@ fn setup_udp_pair() -> UdpPair {
       }
       sockaddr.sin_family = libc::AF_INET as libc::sa_family_t;
       sockaddr.sin_port = addr.port().to_be();
-      sockaddr.sin_addr = libc::in_addr { s_addr: u32::from(*addr.ip()).to_be() };
+      sockaddr.sin_addr =
+        libc::in_addr { s_addr: u32::from(*addr.ip()).to_be() };
       sockaddr
     }
     SocketAddr::V6(_) => unreachable!("IPv4-only test helper"),
@@ -128,8 +130,9 @@ fn basic() {
   let UdpPair { sender, receiver, receiver_addr } = setup_udp_pair();
 
   let data = b"Hello, Receiver!".to_vec();
-  let mut sender_op =
-    api::sendto(&sender, data.clone(), receiver_addr, None).with_lio(&mut lio).send();
+  let mut sender_op = api::sendto(&sender, data.clone(), receiver_addr, None)
+    .with_lio(&mut lio)
+    .send();
 
   let (bytes_sent, returned_buf) = poll_recv(&mut lio, &mut sender_op);
   let bytes_sent = bytes_sent.expect("sendto failed") as usize;
@@ -214,12 +217,14 @@ fn large_data() {
 #[test]
 fn tcp_stream() {
   let mut lio = Lio::new(64).unwrap();
-  let TcpPair { server_sock: _, client_sock, accepted_fd } = setup_tcp_pair(&mut lio);
+  let TcpPair { server_sock: _, client_sock, accepted_fd } =
+    setup_tcp_pair(&mut lio);
 
   let data = b"tcp sendto".to_vec();
   let peer_addr = get_peer_addr(&client_sock);
-  let mut sender_op =
-    api::sendto(&client_sock, data.clone(), peer_addr, None).with_lio(&mut lio).send();
+  let mut sender_op = api::sendto(&client_sock, data.clone(), peer_addr, None)
+    .with_lio(&mut lio)
+    .send();
 
   let (bytes_sent, returned_buf) = poll_recv(&mut lio, &mut sender_op);
   assert_eq!(returned_buf, data);

--- a/lio/tests/ops/shutdown.rs
+++ b/lio/tests/ops/shutdown.rs
@@ -1,8 +1,10 @@
-#![allow(clippy::duplicate_mod, clippy::unnecessary_mut_passed, clippy::expect_fun_call)]
+#![allow(
+  clippy::duplicate_mod,
+  clippy::unnecessary_mut_passed,
+  clippy::expect_fun_call
+)]
 
-mod common;
-
-use common::poll_recv;
+use super::common::{self, poll_recv};
 use lio::api::resource::Resource;
 use lio::{Lio, api};
 use std::mem::MaybeUninit;
@@ -14,11 +16,7 @@ fn test_shutdown_write() {
   let mut lio = Lio::new(64).unwrap();
 
   // Create server socket
-  let server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let server_sock = server_sock.recv().unwrap();
+  let server_sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
   let bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -48,11 +46,7 @@ fn test_shutdown_write() {
   listen_recv.recv().expect("Failed to listen");
 
   // Create client socket
-  let client_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let client_sock = client_sock.recv().unwrap();
+  let client_sock = common::tcp_socket();
 
   // Connect client to server
   let mut connect_recv =
@@ -104,11 +98,7 @@ fn test_shutdown_write() {
 fn test_shutdown_read() {
   let mut lio = Lio::new(64).unwrap();
 
-  let server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let server_sock = server_sock.recv().unwrap();
+  let server_sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
   let bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -138,11 +128,7 @@ fn test_shutdown_read() {
   listen_recv.recv().expect("Failed to listen");
 
   // Create client socket
-  let client_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let client_sock = client_sock.recv().unwrap();
+  let client_sock = common::tcp_socket();
 
   // Connect client to server
   let mut connect_recv =
@@ -186,9 +172,7 @@ fn test_shutdown_read() {
 fn test_shutdown_both() {
   let mut lio = Lio::new(64).unwrap();
 
-  let mut server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  let server_sock = poll_recv(&mut lio, &mut server_sock).unwrap();
+  let server_sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
   let mut bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -215,9 +199,7 @@ fn test_shutdown_both() {
   poll_recv(&mut lio, &mut listen_recv).expect("Failed to listen");
 
   // Create client socket
-  let mut client_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  let client_sock = poll_recv(&mut lio, &mut client_sock).unwrap();
+  let client_sock = common::tcp_socket();
 
   // Connect client to server
   let mut connect_recv =
@@ -280,11 +262,7 @@ fn test_shutdown_invalid_fd() {
 fn test_shutdown_after_close() {
   let mut lio = Lio::new(64).unwrap();
 
-  let server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let server_sock = server_sock.recv().expect("Failed to create server socket");
+  let server_sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
   let bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -313,9 +291,7 @@ fn test_shutdown_after_close() {
 
   listen_recv.recv().expect("Failed to listen");
 
-  let mut client_sock_recv = common::tcp_socket().with_lio(&mut lio).send();
-
-  let client_sock = poll_recv(&mut lio, &mut client_sock_recv).unwrap();
+  let client_sock = common::tcp_socket();
 
   let mut connect_recv =
     api::connect(&client_sock, bound_addr).with_lio(&mut lio).send();
@@ -345,11 +321,7 @@ fn test_shutdown_after_close() {
 fn test_shutdown_twice() {
   let mut lio = Lio::new(64).unwrap();
 
-  let server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let server_sock = server_sock.recv().expect("Failed to create server socket");
+  let server_sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
   let bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -379,11 +351,7 @@ fn test_shutdown_twice() {
   listen_recv.recv().expect("Failed to listen");
 
   // Create client socket
-  let client_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let client_sock = client_sock.recv().unwrap();
+  let client_sock = common::tcp_socket();
 
   // Connect client to server
   let mut connect_recv =
@@ -418,11 +386,7 @@ fn test_shutdown_twice() {
 fn test_shutdown_sequential_directions() {
   let mut lio = Lio::new(64).unwrap();
 
-  let server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let server_sock = server_sock.recv().unwrap();
+  let server_sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
   let bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -452,11 +416,7 @@ fn test_shutdown_sequential_directions() {
   listen_recv.recv().expect("Failed to listen");
 
   // Create client socket
-  let client_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let client_sock = client_sock.recv().unwrap();
+  let client_sock = common::tcp_socket();
 
   // Connect client to server
   let mut connect_recv =
@@ -506,11 +466,7 @@ fn test_shutdown_before_data_sent() {
   let mut lio = Lio::new(64).unwrap();
 
   // Create server socket
-  let server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let server_sock = server_sock.recv().expect("Failed to create server socket");
+  let server_sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
   let bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -540,11 +496,7 @@ fn test_shutdown_before_data_sent() {
   listen_recv.recv().expect("Failed to listen");
 
   // Create client socket
-  let client_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let client_sock = client_sock.recv().unwrap();
+  let client_sock = common::tcp_socket();
 
   // Connect client to server
   let mut connect_recv =
@@ -579,12 +531,7 @@ fn test_shutdown_before_data_sent() {
 fn test_shutdown_ipv6() {
   let mut lio = Lio::new(64).unwrap();
 
-  let server_sock = common::tcp6_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let server_sock =
-    server_sock.recv().expect("Failed to create IPv6 server socket");
+  let server_sock = common::tcp6_socket();
 
   let addr: SocketAddr = "[::1]:0".parse().unwrap();
   let bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -614,12 +561,7 @@ fn test_shutdown_ipv6() {
   listen_recv.recv().expect("Failed to listen");
 
   // Create client socket
-  let client_sock = common::tcp6_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let client_sock =
-    client_sock.recv().expect("Failed to create IPv6 client socket");
+  let client_sock = common::tcp6_socket();
 
   // Connect client to server
   let mut connect_recv =
@@ -656,10 +598,7 @@ fn test_shutdown_concurrent() {
 
   // Test shutting down multiple connections (sequentially)
   for _ in 0..5 {
-    let mut server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-    let server_sock = poll_recv(&mut lio, &mut server_sock)
-      .expect("Failed to create server socket");
+    let server_sock = common::tcp_socket();
 
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
     let mut bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -686,9 +625,7 @@ fn test_shutdown_concurrent() {
     poll_recv(&mut lio, &mut listen_recv).expect("Failed to listen");
 
     // Create and connect client
-    let mut client_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-    let client_sock = poll_recv(&mut lio, &mut client_sock).unwrap();
+    let client_sock = common::tcp_socket();
 
     let mut connect_recv =
       api::connect(&client_sock, bound_addr).with_lio(&mut lio).send();
@@ -715,11 +652,7 @@ fn test_shutdown_concurrent() {
 fn test_shutdown_with_pending_data() {
   let mut lio = Lio::new(64).unwrap();
 
-  let server_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let server_sock = server_sock.recv().unwrap();
+  let server_sock = common::tcp_socket();
 
   let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
   let bind_recv = api::bind(&server_sock, addr).with_lio(&mut lio).send();
@@ -749,11 +682,7 @@ fn test_shutdown_with_pending_data() {
   listen_recv.recv().expect("Failed to listen");
 
   // Create client socket
-  let client_sock = common::tcp_socket().with_lio(&mut lio).send();
-
-  lio.try_run().unwrap();
-
-  let client_sock = client_sock.recv().unwrap();
+  let client_sock = common::tcp_socket();
 
   // Connect client to server
   let mut connect_recv =


### PR DESCRIPTION
## Summary
- include bind, listen, and shutdown ops test modules in the ops integration suite
- adapt those tests to use the shared nested ops common module
- update socket setup to use current Resource-returning helpers and avoid fixed ports in concurrent bind coverage

## Test Plan
- cargo fmt -p lio
- cargo test -p lio --test ops bind -- --nocapture
- cargo test -p lio --test ops listen -- --nocapture
- cargo test -p lio --test ops shutdown -- --nocapture
- cargo test -p lio --test ops